### PR TITLE
Fix bug where CLI fails if "--start-dt" is not provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+test-data/output/
 *.lock
 
 # Byte-compiled / optimized / DLL files

--- a/usgs_gages.py
+++ b/usgs_gages.py
@@ -66,7 +66,6 @@ class UsgsSiteServiceRequest:
         self.lat_north = lat_north
 
     def get(self) -> requests.Response:
-        self.start_dt.isoformat()
         response = requests.get(USGS_SITE_API_BASE_URL, {
             'format': 'rdb',
             'bBox': f'{self.lon_west:.7f},{self.lat_south:.7f},{self.lon_east:.7f},{self.lat_north:.7f}',


### PR DESCRIPTION
CLI fails because of a stray line trying call `.isoformat()` on a potentially `None` value.